### PR TITLE
Feature 36: Funções de Priority Queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,9 @@ endif(BUILD_TESTING)
 #============================================================ LIBRARY
 include_directories(include)
 set(GRAFEO_HDR
-<<<<<<< HEAD
     include/grafeo/pqueue.h
-=======
+    include/grafeo/bucket.h
     include/grafeo/slist.h
->>>>>>> develop
     include/grafeo/list.h
     include/grafeo/type.h
     include/grafeo/array.h
@@ -117,11 +115,9 @@ set(GRAFEO_HDR
     include/grafeo/image.h
 )
 set(GRAFEO_SRC
-<<<<<<< HEAD
  src/pqueue.c
-=======
+ src/bucket.c
  src/slist.c
->>>>>>> develop
  src/array.c
  src/list.c
  src/queue.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ endif(BUILD_TESTING)
 #============================================================ LIBRARY
 include_directories(include)
 set(GRAFEO_HDR
+    include/grafeo/pqueue.h
     include/grafeo/list.h
     include/grafeo/type.h
     include/grafeo/array.h
@@ -112,6 +113,7 @@ set(GRAFEO_HDR
     include/grafeo/image.h
 )
 set(GRAFEO_SRC
+ src/pqueue.c
  src/array.c
  src/list.c
  src/queue.c
@@ -184,7 +186,7 @@ if(BUILD_TESTING)
     add_definitions(-fprofile-arcs -ftest-coverage -pg)
 
     # Array
-    list(APPEND TESTS_NAMES array image list queue)
+    list(APPEND TESTS_NAMES array image list queue pqueue)
     include (CTest)
     foreach(testname ${TESTS_NAMES})
         if(NOT CMOCKA_FOUND)

--- a/include/grafeo/bucket.h
+++ b/include/grafeo/bucket.h
@@ -25,38 +25,53 @@
 #   License along with Grafeo.  If not, see
 #   <http://www.gnu.org/licenses/>.
 # ===================================================================*/
-#ifndef GRAFEO_PQUEUE_H
-#define GRAFEO_PQUEUE_H
-
-#include <grafeo/bucket.h>
+#ifndef GRAFEO_BUCKET_H
+#define GRAFEO_BUCKET_H
 #include <grafeo/queue.h>
-
 /**
- * @brief pqueue_append
- * @param pqueue
+ * @brief Bucket structure, just a queue with an additional attribute which
+ * is the same for every item
+ *
+ * You can put additional attributes just by extending Bucket, or inserting
+ * a struct of attributes in the `value` variable.
+ */
+typedef struct _Bucket{
+  Queue* queue; /**< Queue of elements in the bucket */
+  void*  value; /**< Unique attribute of the queue */
+}Bucket;
+/**
+ * @brief bucket_new
+ * @return
+ */
+Bucket* bucket_new();
+/**
+ * @brief bucket_queue
+ * @param bucket
+ * @return
+ */
+Queue*  bucket_queue(Bucket* bucket);
+/**
+ * @brief bucket_value
+ * @param bucket
+ * @return
+ */
+void*   bucket_value(Bucket* bucket);
+/**
+ * @brief bucket_set_queue
+ * @param bucket
+ * @param queue
+ */
+void    bucket_set_queue(Bucket* bucket,Queue* queue);
+/**
+ * @brief bucket_set_value
  * @param bucket
  * @param value
  */
-void  pqueue_append(Queue* pqueue, void* bucket, void* value);
+void    bucket_set_value(Bucket* bucket, void* value);
 /**
- * @brief pqueue_bucket_remove_begin
- * @param pqueue
+ * @brief bucket_free
  * @param bucket
- * @return
  */
-void* pqueue_bucket_remove_begin(Queue* pqueue,  void* bucket);
-/**
- * @brief pqueue_bucket_remove_end
- * @param pqueue
- * @param bucket
- * @return
- */
-void* pqueue_bucket_remove_end(Queue* pqueue,    void* bucket);
-/**
- * @brief pqueue_bucket_is_empty
- * @param pqueue
- * @param bucket
- * @return
- */
-uint8_t pqueue_bucket_is_empty(Queue* pqueue,    void* bucket);
+void    bucket_free(Bucket* bucket);
+
 #endif

--- a/include/grafeo/pqueue.h
+++ b/include/grafeo/pqueue.h
@@ -31,13 +31,18 @@
 #include <grafeo/bucket.h>
 #include <grafeo/queue.h>
 
-/**
- * @brief pqueue_append
- * @param pqueue
- * @param bucket
- * @param value
- */
-void  pqueue_append(Queue* pqueue, void* bucket, void* value);
+void  pqueue_append_at(Queue* pqueue, void* bucket, void* value);
+void  pqueue_prepend_at(Queue* pqueue, void* bucket, void* value);
+void  pqueue_prepend(Queue* pqueue, void* value);
+void  pqueue_append(Queue* pqueue, void* value);
+void  pqueue_remove_begin_at(Queue* pqueue, void* bucket);
+void  pqueue_remove_end_at  (Queue* pqueue, void* bucket);
+void  pqueue_remove_begin(Queue* pqueue);
+void  pqueue_remove_end(Queue* pqueue);
+void  pqueue_shrink(Queue* pqueue);
+void* pqueue_at(Queue* pqueue, uint32_t bucket_index);
+void* pqueue_bucket_at(Queue* pqueue, uint32_t bucket_index, uint32_t index);
+
 /**
  * @brief pqueue_bucket_remove_begin
  * @param pqueue
@@ -59,4 +64,5 @@ void* pqueue_bucket_remove_end(Queue* pqueue,    void* bucket);
  * @return
  */
 uint8_t pqueue_bucket_is_empty(Queue* pqueue,    void* bucket);
+
 #endif

--- a/src/bucket.c
+++ b/src/bucket.c
@@ -27,6 +27,10 @@
 # ===================================================================*/
 #include <grafeo/bucket.h>
 
+Bucket* bucket_new(){
+  return malloc(sizeof(Bucket));
+}
+
 Queue* bucket_queue(Bucket *bucket){
   return bucket->queue;
 }

--- a/src/bucket.c
+++ b/src/bucket.c
@@ -1,0 +1,52 @@
+/* ===================================================================
+#   Copyright (C) 2015-2015
+#   Anderson Tavares <nocturne.pe at gmail.com> PK 0x38e7bfc5c2def8ff
+#   Lucy Mansilla    <lucyacm at gmail.com>
+#   Caio de Braz     <caiobraz at gmail.com>
+#   Hans Harley      <hansbecc at gmail.com>
+#   Paulo Miranda    <pavmbr at yahoo.com.br>
+#
+#   Institute of Mathematics and Statistics - IME
+#   University of Sao Paulo - USP
+#
+#   This file is part of Grafeo.
+#
+#   Grafeo is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   as published by the Free Software Foundation, either version
+#   3 of the License, or (at your option) any later version.
+#
+#   Grafeo is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#   See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with Grafeo.  If not, see
+#   <http://www.gnu.org/licenses/>.
+# ===================================================================*/
+#include <grafeo/bucket.h>
+
+Queue* bucket_queue(Bucket *bucket){
+  return bucket->queue;
+}
+
+void *bucket_value(Bucket *bucket)
+{
+  return bucket->value;
+}
+
+void bucket_set_queue(Bucket *bucket, Queue *queue)
+{
+  bucket->queue = queue;
+}
+
+void bucket_set_value(Bucket *bucket, void *value)
+{
+  bucket->value = value;
+}
+
+void bucket_free(Bucket *bucket)
+{
+  free(bucket);
+}

--- a/src/pqueue.c
+++ b/src/pqueue.c
@@ -27,10 +27,29 @@
 # ===================================================================*/
 #include <grafeo/pqueue.h>
 
-void pqueue_append_at(Queue *pqueue, void *bucket, void *value){
-
+void pqueue_append_at(Queue *pqueue, void *value_bucket, void *value){
+  List* bucket_item = NULL;
+  uint8_t is_new    = 1;
+  for(bucket_item = queue_begin(pqueue); bucket_item; bucket_item = list_next(bucket_item)){
+    Bucket* bucket = (Bucket*)list_value(bucket_item);
+    // Found the bucket
+    if(bucket_value(bucket) == value_bucket){
+      queue_append(bucket_queue(bucket), value);
+      is_new = 0;
+    }
+    else if(bucket_value(bucket) > value_bucket) break;
+  }
+  // Insert the new bucket if found proper place
+  if(is_new){
+    Bucket* new_bucket = bucket_new();
+    bucket_set_queue(new_bucket, queue_new());
+    bucket_set_value(new_bucket, value_bucket);
+    queue_append(bucket_queue(new_bucket),value);
+    if(bucket_item) queue_prepend_at(pqueue, bucket_item, new_bucket);
+    else            queue_append(pqueue, new_bucket);
+  }
 }
-void  pqueue_prepend_at(Queue* pqueue, void* bucket, void* value){
+void  pqueue_prepend_at(Queue* pqueue, void* bucket_value, void* value){
 
 }
 void  pqueue_remove_begin_at(Queue* pqueue, void* bucket){

--- a/src/pqueue.c
+++ b/src/pqueue.c
@@ -1,0 +1,56 @@
+/* ===================================================================
+#   Copyright (C) 2015-2015
+#   Anderson Tavares <nocturne.pe at gmail.com> PK 0x38e7bfc5c2def8ff
+#   Lucy Mansilla    <lucyacm at gmail.com>
+#   Caio de Braz     <caiobraz at gmail.com>
+#   Hans Harley      <hansbecc at gmail.com>
+#   Paulo Miranda    <pavmbr at yahoo.com.br>
+#
+#   Institute of Mathematics and Statistics - IME
+#   University of Sao Paulo - USP
+#
+#   This file is part of Grafeo.
+#
+#   Grafeo is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   as published by the Free Software Foundation, either version
+#   3 of the License, or (at your option) any later version.
+#
+#   Grafeo is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#   See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with Grafeo.  If not, see
+#   <http://www.gnu.org/licenses/>.
+# ===================================================================*/
+#include <grafeo/pqueue.h>
+
+void pqueue_append_at(Queue *pqueue, void *bucket, void *value){
+
+}
+void  pqueue_prepend_at(Queue* pqueue, void* bucket, void* value){
+
+}
+void  pqueue_remove_begin_at(Queue* pqueue, void* bucket){
+
+}
+void  pqueue_remove_end_at  (Queue* pqueue, void* bucket){
+
+}
+void  pqueue_remove_begin(Queue* pqueue){
+
+}
+void  pqueue_remove_end(Queue* pqueue){
+
+}
+void  pqueue_shrink(Queue* pqueue){
+
+}
+void* pqueue_at(Queue* pqueue, uint32_t index){
+
+}
+void* pqueue_bucket_at(Queue* pqueue, uint32_t bucket_index, uint32_t index){
+
+}

--- a/src/pqueue.c
+++ b/src/pqueue.c
@@ -36,6 +36,7 @@ void pqueue_append_at(Queue *pqueue, void *value_bucket, void *value){
     if(bucket_value(bucket) == value_bucket){
       queue_append(bucket_queue(bucket), value);
       is_new = 0;
+      break;
     }
     else if(bucket_value(bucket) > value_bucket) break;
   }
@@ -49,27 +50,72 @@ void pqueue_append_at(Queue *pqueue, void *value_bucket, void *value){
     else            queue_append(pqueue, new_bucket);
   }
 }
-void  pqueue_prepend_at(Queue* pqueue, void* bucket_value, void* value){
 
+// Adicionar na lista de bucket o valor
+void  pqueue_prepend_at(Queue* pqueue, void* value_bucket, void* value){
+  List* bucket_item = NULL;
+  uint8_t is_new    = 1;
+  // Procura pelo bucket
+  for(bucket_item = queue_begin(pqueue); bucket_item; bucket_item = list_next(bucket_item)){
+    Bucket* bucket = (Bucket*)list_value(bucket_item);
+    // Found the bucket
+    if(bucket_value(bucket) == value_bucket){
+      queue_prepend(bucket_queue(bucket), value);
+      is_new = 0;
+      break;
+    }
+    else if(bucket_value(bucket) > value_bucket) break;
+  }
+  if(is_new){
+    Bucket* new_bucket = bucket_new();
+    bucket_set_queue(new_bucket, queue_new());
+    bucket_set_value(new_bucket, value_bucket);
+    // Add the item to the bucket queue
+    queue_prepend(bucket_queue(new_bucket), value);
+    // Add the bucket to the main queue
+    if(bucket_item) queue_prepend_at(pqueue, bucket_item, new_bucket);
+    else            queue_append(pqueue, new_bucket);
+  }
 }
-void  pqueue_remove_begin_at(Queue* pqueue, void* bucket){
-
+void  pqueue_remove_begin_at(Queue* pqueue, void* value_bucket){
+  List* bucket_item = NULL;
+  for(bucket_item = queue_begin(pqueue); bucket_item; bucket_item = list_next(bucket_item)){
+    Bucket* bucket = (Bucket*) list_value(bucket_item);
+    if(bucket_value(bucket) == value_bucket){
+      queue_remove_begin(bucket_queue(bucket));
+      break;
+    }
+  }
 }
-void  pqueue_remove_end_at  (Queue* pqueue, void* bucket){
-
+void  pqueue_remove_end_at  (Queue* pqueue, void* value_bucket){
+  List* bucket_item = NULL;
+  for(bucket_item = queue_begin(pqueue); bucket_item; bucket_item = list_next(bucket_item)){
+    Bucket* bucket = (Bucket*) list_value(bucket_item);
+    if(bucket_value(bucket) == value_bucket){
+      queue_remove_end(bucket_queue(bucket));
+      break;
+    }
+  }
 }
 void  pqueue_remove_begin(Queue* pqueue){
-
+  // Get the begin of queue and remove its first item
+  queue_remove_begin(bucket_queue((Bucket*)list_value(queue_begin(pqueue))));
 }
 void  pqueue_remove_end(Queue* pqueue){
-
+  // Get the begin of queue and remove its last item
+  queue_remove_end(bucket_queue((Bucket*)list_value(queue_begin(pqueue))));
 }
 void  pqueue_shrink(Queue* pqueue){
-
+  Bucket* bucket = (Bucket*)list_value(queue_begin(pqueue));
+  if(queue_is_empty(bucket_queue(bucket))){
+    queue_free(bucket_queue(bucket));
+    bucket_free(bucket);
+    queue_remove_begin(pqueue);
+  }
 }
 void* pqueue_at(Queue* pqueue, uint32_t index){
-
+  return bucket_value((Bucket*) list_value(queue_at(pqueue,index)));
 }
 void* pqueue_bucket_at(Queue* pqueue, uint32_t bucket_index, uint32_t index){
-
+  return list_value(queue_at(bucket_queue((Bucket*) list_value(queue_at(pqueue,bucket_index))),index));
 }

--- a/tests/test_pqueue.c
+++ b/tests/test_pqueue.c
@@ -111,23 +111,32 @@ static void test_pqueue_adding_removing(void ** state){
   // Removing the first value of the first bucket
   // It doesn't automatically remove the empty bucket
   pqueue_remove_begin(pqueue);
-  helper_pqueue_elements(pqueue, {3,7,9}, {{},{5},{6}}, 3, {0,1,1});
+  uint8_t  bucketslists71[0]  = {};
+  uint8_t  bucketslists72[1]  = {5};
+  uint8_t* bucketslists7[2]   = {bucketslists71,bucketslists72,bucketslists43};
+  uint8_t  bucketslengths7[2] = {0,1,1};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists7, 3, bucketslengths7);
 
   // Adding a value in the empty bucket
   pqueue_prepend(pqueue, IP(3), IP(10));
-  helper_pqueue_elements(pqueue, {3,7,9}, {{10},{5},{6}}, 3, {1,1,1});
+  uint8_t  bucketslists81[0]  = {10};
+  uint8_t* bucketslists8[3]   = {bucketslists81,bucketslists72,bucketslists43};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists8, 3, bucketslengths6);
 
   // Adding another value in the empty bucket
   pqueue_prepend(pqueue, IP(3), IP(11));
-  helper_pqueue_elements(pqueue, {3,7,9}, {{11,10},{5},{6}}, 3, {2,1,1});
+  uint8_t  bucketslists91[2]  = {11,10};
+  uint8_t* bucketslists9[3]   = {bucketslists91,bucketslists72,bucketslists43};
+  uint8_t  bucketslengths9[2] = {2,1,1};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists9, 3, bucketslengths9);
 
   // Removing the last value of the first bucket
   pqueue_remove_end(pqueue);
-  helper_pqueue_elements(pqueue, {3,7,9}, {{11},{5},{6}}, 3, {1,1,1});
+  helper_pqueue_elements(pqueue, buckets4, {{11},{5},{6}}, 3, {1,1,1});
 
   // Removing the last value of the first bucket
   pqueue_remove_end(pqueue);
-  helper_pqueue_elements(pqueue, {3,7,9}, {{},{5},{6}}, 3, {0,1,1});
+  helper_pqueue_elements(pqueue, buckets4, {{},{5},{6}}, 3, {0,1,1});
 
   // Shrink Queue (removing first bucket if it's empty)
   pqueue_shrink(pqueue);

--- a/tests/test_pqueue.c
+++ b/tests/test_pqueue.c
@@ -1,0 +1,157 @@
+/* ===================================================================
+#   Copyright (C) 2015-2015
+#   Anderson Tavares <nocturne.pe at gmail.com> PK 0x38e7bfc5c2def8ff
+#   Lucy Mansilla    <lucyacm at gmail.com>
+#   Caio de Braz     <caiobraz at gmail.com>
+#   Hans Harley      <hansbecc at gmail.com>
+#   Paulo Miranda    <pavmbr at yahoo.com.br>
+#
+#   Institute of Mathematics and Statistics - IME
+#   University of Sao Paulo - USP
+#
+#   This file is part of Grafeo.
+#
+#   Grafeo is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   as published by the Free Software Foundation, either version
+#   3 of the License, or (at your option) any later version.
+#
+#   Grafeo is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#   See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with Grafeo.  If not, see
+#   <http://www.gnu.org/licenses/>.
+# ===================================================================*/
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <grafeo/pqueue.h>
+
+static void helper_pqueue_elements(Queue* pqueue, uint8_t* pqueue_values, uint8_t** bucket_values, uint8_t pqueue_length, uint8_t* bucket_lengths){
+  // Test queue length
+  assert_int_equal(queue_length(pqueue), pqueue_length);
+  uint8_t i;
+  List* current = pqueue->begin;
+  for(i = 0, current = queue_begin(pqueue); i < pqueue_length; i++, current = list_next(current)){
+    Bucket* bucket = (Bucket*)list_value(current);
+    Queue* queueBucket = bucket_queue(bucket);
+    // Test bucket length
+    assert_int_equal(queue_length(queueBucket), bucket_lengths[i]);
+    // Test bucket value
+    assert_int_equal(bucket_value(bucket), pqueue_values[i]);
+    // Test bucket queue values
+    List* currentb;
+    uint8_t j;
+    for(j = 0, currentb = queue_begin(queueBucket); j < bucket_lengths[i]; j++, currentb = list_next(currentb))
+      assert_int_equal(list_value(currentb),bucket_values[i][j]);
+  }
+}
+
+static void test_pqueue_adding_removing(void ** state){
+  (void) state;
+  Queue* pqueue  = queue_new();
+#define IP(x) INT8_TO_POINTER(x)
+  // Appending a value in a bucket
+  pqueue_append(pqueue,IP(7), IP(5));
+  uint8_t  buckets1[1]        = {7};
+  uint8_t  bucketslists11[1]  = {5};
+  uint8_t* bucketslists1[1]   = {bucketslists11};
+  uint8_t  bucketslengths1[1] = {1};
+  helper_pqueue_elements(pqueue, buckets1, bucketslists1, 1, bucketslengths1);
+
+  // Appending another value in a bucket
+  pqueue_append(pqueue,IP(7), IP(3));
+  uint8_t  bucketslists21[2]  = {5,3};
+  uint8_t* bucketslists2[1]   = {bucketslists21};
+  uint8_t  bucketslengths2[1] = {2};
+  helper_pqueue_elements(pqueue, buckets1, bucketslists2, 1, bucketslengths2);
+
+  // Appending another value in another bucket
+  pqueue_append(pqueue,IP(9), IP(6));
+  uint8_t  buckets3[2]        = {7,9};
+  uint8_t  bucketslists31[2]  = {5,3};
+  uint8_t  bucketslists32[1]  = {6};
+  uint8_t* bucketslists3[2]   = {bucketslists31,bucketslists32};
+  uint8_t  bucketslengths3[2] = {2,1};
+  helper_pqueue_elements(pqueue, buckets3, bucketslists3, 2, bucketslengths3);
+
+  // Prepending a value in a new bucket
+  pqueue_prepend(pqueue, IP(3), IP(4));
+  uint8_t  buckets4[3]        = {3,7,9};
+  uint8_t  bucketslists41[1]  = {4};
+  uint8_t  bucketslists42[2]  = {5,3};
+  uint8_t  bucketslists43[1]  = {6};
+  uint8_t* bucketslists4[2]   = {bucketslists41,bucketslists42,bucketslists43};
+  uint8_t  bucketslengths4[3] = {1,2,1};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists4, 3, bucketslengths4);
+
+  // Prepending a value in a existante bucket
+  pqueue_prepend(pqueue, IP(7), IP(4));
+  uint8_t  bucketslists52[3]  = {4,5,3};
+  uint8_t* bucketslists5[3]   = {bucketslists41,bucketslists52,bucketslists43};
+  uint8_t  bucketslengths5[3] = {1,3,1};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists5, 3, bucketslengths5);
+
+  // Removing the first value in a bucket
+  pqueue_remove_begin_of(pqueue, IP(7));
+  helper_pqueue_elements(pqueue, buckets4, bucketslists4, 3, bucketslengths4);
+
+  // Removing the last value in a bucket
+  pqueue_remove_end_of(pqueue, IP(7));
+  uint8_t  bucketslists62[1]  = {5};
+  uint8_t* bucketslists6[3]   = {bucketslists41,bucketslists62,bucketslists43};
+  uint8_t  bucketslengths6[2] = {1,1,1};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists6, 3, bucketslengths6);
+
+  // Removing the first value of the first bucket
+  // It doesn't automatically remove the empty bucket
+  pqueue_remove_begin(pqueue);
+  helper_pqueue_elements(pqueue, {3,7,9}, {{},{5},{6}}, 3, {0,1,1});
+
+  // Adding a value in the empty bucket
+  pqueue_prepend(pqueue, IP(3), IP(10));
+  helper_pqueue_elements(pqueue, {3,7,9}, {{10},{5},{6}}, 3, {1,1,1});
+
+  // Adding another value in the empty bucket
+  pqueue_prepend(pqueue, IP(3), IP(11));
+  helper_pqueue_elements(pqueue, {3,7,9}, {{11,10},{5},{6}}, 3, {2,1,1});
+
+  // Removing the last value of the first bucket
+  pqueue_remove_end(pqueue);
+  helper_pqueue_elements(pqueue, {3,7,9}, {{11},{5},{6}}, 3, {1,1,1});
+
+  // Removing the last value of the first bucket
+  pqueue_remove_end(pqueue);
+  helper_pqueue_elements(pqueue, {3,7,9}, {{},{5},{6}}, 3, {0,1,1});
+
+  // Shrink Queue (removing first bucket if it's empty)
+  pqueue_shrink(pqueue);
+  helper_pqueue_elements(pqueue, {7,9}, {{5},{6}}, 2, {1,1});
+
+  // Looking for the bucket value
+  void* value = pqueue_at(pqueue, 1);
+  assert_int_equal(value, 9);
+
+  // Looking for a value in a bucket queue
+  value = pqueue_bucket_at(pqueue, 1, 0);
+  assert_int_equal(value, 6);
+
+  queue_free(pqueue);
+}
+
+int main(int argc, char** argv){
+  (void)argc;
+  (void)argv;
+  const struct CMUnitTest tests[]={
+    cmocka_unit_test(test_pqueue_adding_removing),
+    cmocka_unit_test(test_pqueue_accessors),
+    cmocka_unit_test(test_pqueue_operations),
+    cmocka_unit_test(test_pqueue_comparisons),
+  };
+  return cmocka_run_group_tests(tests,NULL,NULL);
+}

--- a/tests/test_pqueue.c
+++ b/tests/test_pqueue.c
@@ -57,22 +57,22 @@ static void test_pqueue_adding_removing(void ** state){
   Queue* pqueue  = queue_new();
 #define IP(x) INT8_TO_POINTER(x)
   // Appending a value in a bucket
-  pqueue_append(pqueue,IP(7), IP(5));
+  pqueue_append_at(pqueue,IP(7), IP(5));
   uint8_t  buckets1[1]        = {7};
-  uint8_t  bucketslists11[1]  = {5};
-  uint8_t* bucketslists1[1]   = {bucketslists11};
+  uint8_t  bucketslists011[1]  = {5};
+  uint8_t* bucketslists1[1]   = {bucketslists011};
   uint8_t  bucketslengths1[1] = {1};
   helper_pqueue_elements(pqueue, buckets1, bucketslists1, 1, bucketslengths1);
 
   // Appending another value in a bucket
-  pqueue_append(pqueue,IP(7), IP(3));
+  pqueue_append_at(pqueue,IP(7), IP(3));
   uint8_t  bucketslists21[2]  = {5,3};
   uint8_t* bucketslists2[1]   = {bucketslists21};
   uint8_t  bucketslengths2[1] = {2};
   helper_pqueue_elements(pqueue, buckets1, bucketslists2, 1, bucketslengths2);
 
   // Appending another value in another bucket
-  pqueue_append(pqueue,IP(9), IP(6));
+  pqueue_append_at(pqueue,IP(9), IP(6));
   uint8_t  buckets3[2]        = {7,9};
   uint8_t  bucketslists31[2]  = {5,3};
   uint8_t  bucketslists32[1]  = {6};
@@ -81,31 +81,31 @@ static void test_pqueue_adding_removing(void ** state){
   helper_pqueue_elements(pqueue, buckets3, bucketslists3, 2, bucketslengths3);
 
   // Prepending a value in a new bucket
-  pqueue_prepend(pqueue, IP(3), IP(4));
+  pqueue_prepend_at(pqueue, IP(3), IP(4));
   uint8_t  buckets4[3]        = {3,7,9};
   uint8_t  bucketslists41[1]  = {4};
   uint8_t  bucketslists42[2]  = {5,3};
   uint8_t  bucketslists43[1]  = {6};
-  uint8_t* bucketslists4[2]   = {bucketslists41,bucketslists42,bucketslists43};
+  uint8_t* bucketslists4[3]   = {bucketslists41,bucketslists42,bucketslists43};
   uint8_t  bucketslengths4[3] = {1,2,1};
   helper_pqueue_elements(pqueue, buckets4, bucketslists4, 3, bucketslengths4);
 
   // Prepending a value in a existante bucket
-  pqueue_prepend(pqueue, IP(7), IP(4));
+  pqueue_prepend_at(pqueue, IP(7), IP(4));
   uint8_t  bucketslists52[3]  = {4,5,3};
   uint8_t* bucketslists5[3]   = {bucketslists41,bucketslists52,bucketslists43};
   uint8_t  bucketslengths5[3] = {1,3,1};
   helper_pqueue_elements(pqueue, buckets4, bucketslists5, 3, bucketslengths5);
 
   // Removing the first value in a bucket
-  pqueue_remove_begin_of(pqueue, IP(7));
+  pqueue_remove_begin_at(pqueue, IP(7));
   helper_pqueue_elements(pqueue, buckets4, bucketslists4, 3, bucketslengths4);
 
   // Removing the last value in a bucket
-  pqueue_remove_end_of(pqueue, IP(7));
+  pqueue_remove_end_at(pqueue, IP(7));
   uint8_t  bucketslists62[1]  = {5};
   uint8_t* bucketslists6[3]   = {bucketslists41,bucketslists62,bucketslists43};
-  uint8_t  bucketslengths6[2] = {1,1,1};
+  uint8_t  bucketslengths6[3] = {1,1,1};
   helper_pqueue_elements(pqueue, buckets4, bucketslists6, 3, bucketslengths6);
 
   // Removing the first value of the first bucket
@@ -113,34 +113,39 @@ static void test_pqueue_adding_removing(void ** state){
   pqueue_remove_begin(pqueue);
   uint8_t  bucketslists71[0]  = {};
   uint8_t  bucketslists72[1]  = {5};
-  uint8_t* bucketslists7[2]   = {bucketslists71,bucketslists72,bucketslists43};
-  uint8_t  bucketslengths7[2] = {0,1,1};
+  uint8_t* bucketslists7[3]   = {bucketslists71,bucketslists72,bucketslists43};
+  uint8_t  bucketslengths7[3] = {0,1,1};
   helper_pqueue_elements(pqueue, buckets4, bucketslists7, 3, bucketslengths7);
 
   // Adding a value in the empty bucket
-  pqueue_prepend(pqueue, IP(3), IP(10));
-  uint8_t  bucketslists81[0]  = {10};
+  pqueue_prepend_at(pqueue, IP(3), IP(10));
+  uint8_t  bucketslists81[1]  = {10};
   uint8_t* bucketslists8[3]   = {bucketslists81,bucketslists72,bucketslists43};
   helper_pqueue_elements(pqueue, buckets4, bucketslists8, 3, bucketslengths6);
 
   // Adding another value in the empty bucket
-  pqueue_prepend(pqueue, IP(3), IP(11));
+  pqueue_prepend_at(pqueue, IP(3), IP(11));
   uint8_t  bucketslists91[2]  = {11,10};
   uint8_t* bucketslists9[3]   = {bucketslists91,bucketslists72,bucketslists43};
-  uint8_t  bucketslengths9[2] = {2,1,1};
+  uint8_t  bucketslengths9[3] = {2,1,1};
   helper_pqueue_elements(pqueue, buckets4, bucketslists9, 3, bucketslengths9);
 
   // Removing the last value of the first bucket
   pqueue_remove_end(pqueue);
-  helper_pqueue_elements(pqueue, buckets4, {{11},{5},{6}}, 3, {1,1,1});
+  uint8_t  bucketslists101[3]  = {11};
+  uint8_t* bucketslists10[3]   = {bucketslists101,bucketslists72,bucketslists43};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists10, 3, bucketslengths6);
 
   // Removing the last value of the first bucket
   pqueue_remove_end(pqueue);
-  helper_pqueue_elements(pqueue, buckets4, {{},{5},{6}}, 3, {0,1,1});
+  uint8_t* bucketslists11[3]   = {bucketslists71,bucketslists72,bucketslists43};
+  helper_pqueue_elements(pqueue, buckets4, bucketslists11, 3, bucketslengths7);
 
   // Shrink Queue (removing first bucket if it's empty)
   pqueue_shrink(pqueue);
-  helper_pqueue_elements(pqueue, {7,9}, {{5},{6}}, 2, {1,1});
+  uint8_t  buckets12[3]        = {7,9};
+  uint8_t* bucketslists12[3]   = {bucketslists72,bucketslists43};
+  helper_pqueue_elements(pqueue, buckets12, bucketslists12, 2, bucketslengths6);
 
   // Looking for the bucket value
   void* value = pqueue_at(pqueue, 1);
@@ -153,14 +158,13 @@ static void test_pqueue_adding_removing(void ** state){
   queue_free(pqueue);
 }
 
+
+
 int main(int argc, char** argv){
   (void)argc;
   (void)argv;
   const struct CMUnitTest tests[]={
     cmocka_unit_test(test_pqueue_adding_removing),
-    cmocka_unit_test(test_pqueue_accessors),
-    cmocka_unit_test(test_pqueue_operations),
-    cmocka_unit_test(test_pqueue_comparisons),
   };
   return cmocka_run_group_tests(tests,NULL,NULL);
 }


### PR DESCRIPTION
Adicionar e remover valores em buckets
Por enquanto só serve para números (por causa da comparação ==). Pode ser necessário depois receber uma função de comparação para ordenar os buckets, por exemplo se as chaves dos buckets são strings